### PR TITLE
Fixed code logic in Notification.class

### DIFF
--- a/src/docs/asciidoc/app-structure.asc
+++ b/src/docs/asciidoc/app-structure.asc
@@ -724,9 +724,14 @@ public class Notifications {
 
         List<SubscriberObject> subscriberList = instance.subscribers.get( event );
 
-        if (subscriberList == null) {
-            subscriberList.remove( subscriber );
-        }
+        if (subscriberList != null) {
+		for(SubscriberObject sObj : subscriberList) {
+			if(sObj.getSubscriber().equals(subscriber)) {
+				subscriberList.remove(sObj);
+			}
+		}
+	}
+        
     }
 
     static class SubscriberObject {
@@ -755,7 +760,13 @@ public class Notifications {
 
         @Override
         public boolean equals(Object obj) {
-            return subscriber.equals(obj);
+            if(!(obj instanceof SubscriberObject)) {
+	    	return false;
+	    }
+	    else {
+	    	SubscriberObject otherSObj = (SubscriberObject) obj;
+		return Objects.equals(subscriber, otherSObj.subscriber);
+	    }
         }
     }
 }


### PR DESCRIPTION
reason for chaning == to != should be obvious at line 727 moreover, simply calling the remove( )function on subscriberList while passing subscriber is not functional; since each item of subscriberList will be tested for equality against the subscriber, and not the other way around; in other words, it's the subscriber's equal() function which is getting called, therefore it always returns false. alongside this fixture a small change is also applied on SubscriberObject's equal() method.