### PR TITLE
Fix typo in ui-controls.asc

### DIFF
--- a/src/docs/asciidoc/ui-controls.asc
+++ b/src/docs/asciidoc/ui-controls.asc
@@ -919,7 +919,7 @@ ImageView is a Node container that allows the Image object to be used in JavaFX 
         iv4.setViewport(viewportRect);
 ----
 
-iv3 and iv3 are based on the image2 and image3 objects.  Recall that these objects produced transformed images that fit the square container.
+iv2 and iv3 are based on the image2 and image3 objects.  Recall that these objects produced transformed images that fit the square container.
 
 iv4 is also based on a transformed Image object, but in the case of iv4, the transformation is done through the ImageView object rather than the Image.  ImageView.setFitHeight is called rather than Image.setFitHeight.
 


### PR DESCRIPTION
Fix typo "iv3 and iv3 are" to "iv2 and iv3 are" in the ui-controls.asc file